### PR TITLE
Fix accuracy-microbench and accuracy-embench CI timeouts

### DIFF
--- a/.github/workflows/accuracy-embench.yml
+++ b/.github/workflows/accuracy-embench.yml
@@ -23,7 +23,7 @@ jobs:
   embench-accuracy:
     name: EmBench Accuracy
     runs-on: macos-14
-    timeout-minutes: 30
+    timeout-minutes: 120
 
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
           > embench_output.txt
           for TEST in "${TESTS[@]}"; do
             echo "--- $TEST ---"
-            go test -v -run "^${TEST}$" -count=1 -timeout 5m ./benchmarks/ 2>&1 | tee -a embench_output.txt || true
+            go test -v -run "^${TEST}$" -count=1 -timeout 15m ./benchmarks/ 2>&1 | tee -a embench_output.txt || true
           done
 
       - name: Extract CPI results

--- a/.github/workflows/accuracy-microbench.yml
+++ b/.github/workflows/accuracy-microbench.yml
@@ -17,7 +17,7 @@ jobs:
   microbench-accuracy:
     name: Microbenchmark Accuracy
     runs-on: macos-14
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
@@ -35,6 +35,9 @@ jobs:
 
       - name: Install Python dependencies
         run: pip install matplotlib numpy scipy
+
+      - name: Warm up Matplotlib font cache
+        run: python3 -c "import matplotlib.pyplot as plt"
 
       - name: Run microbenchmark CPI tests
         run: |


### PR DESCRIPTION
## Summary
- **accuracy-microbench**: Matplotlib font cache build takes ~15 minutes on first run, causing the 15-minute job timeout to cancel the workflow. Fix: add font cache warmup step after installing Python deps, increase job timeout to 30m.
- **accuracy-embench**: Individual EmBench simulations can take >5 minutes. Fix: increase per-test timeout from 5m to 15m, increase job timeout from 30m to 120m.

Supersedes PRs #8 and #9 (combined into a single PR for clean merge).

## Root Cause Analysis
- **Microbench**: The "Generate accuracy report" step runs `accuracy_report.py` which imports matplotlib. On first run in CI, matplotlib builds its font cache, which takes ~15 minutes on macOS runners. This caused the step to hang until the 15-minute job timeout killed it.
- **EmBench**: The per-test `go test -timeout 5m` was too short for some EmBench simulations, and the 30-minute job timeout was insufficient for 7 sequential tests.

## Test plan
- [ ] CI passes on this PR
- [ ] Trigger `workflow_dispatch` for accuracy-microbench after merge
- [ ] Trigger `workflow_dispatch` for accuracy-embench after merge
- [ ] All three accuracy workflows produce artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)